### PR TITLE
Solution for Inled repo signature errors : Optional TrustAll as pearos repo

### DIFF
--- a/packages/pacman.out
+++ b/packages/pacman.out
@@ -78,8 +78,10 @@ LocalFileSigLevel = Optional
 SigLevel = Optional TrustAll
 Server = https://mirror.pearos.xyz/main/x86_64/
 
+# Added Optional TrustaLL to Inled Repo due to pacman keyring errors.
+
 [inled]
-SigLevel = PackageRequired
+SigLevel = Optional TrustAll
 Server = https://apt.inled.es/arch/
 
 [core]

--- a/pear/airootfs/etc/pacman.conf
+++ b/pear/airootfs/etc/pacman.conf
@@ -75,7 +75,7 @@ LocalFileSigLevel = Optional
 #Include = /etc/pacman.d/mirrorlist
 
 [inled]
-SigLevel = PackageRequired
+SigLevel = Optional TrustAll
 Server = https://apt.inled.es/arch/
 
 [pearos]

--- a/pear/pacman.conf
+++ b/pear/pacman.conf
@@ -75,7 +75,7 @@ LocalFileSigLevel = Optional
 #Include = /etc/pacman.d/mirrorlist
 
 [inled]
-SigLevel = PackageRequired
+SigLevel = Optional TrustAll
 Server = https://apt.inled.es/arch/
 
 [pearos]


### PR DESCRIPTION
PearOS may have keyring errors because Inled repo does not fail on Arch Linux vanilla.
This solves the keyring errors as what was made on the pearos repo.